### PR TITLE
re-enable most HTML tags

### DIFF
--- a/pw-mypubs-ui/src/main/webapp/mypubs/publication/bibliodata/bibliodata.js
+++ b/pw-mypubs-ui/src/main/webapp/mypubs/publication/bibliodata/bibliodata.js
@@ -184,7 +184,10 @@
   						},
 					browser_spellcheck : true,
 					toolbar : 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | subscript superscript | link | code',
-					valid_elements : "strong/b,i/em,strike,u,"
+					valid_elements : "@[id|class|style|title|dir<ltr?rtl|lang|xml::lang|onclick|ondblclick|"
+							+ "onmousedown|onmouseup|onmouseover|onmousemove|onmouseout|onkeypress|"
+							+ "onkeydown|onkeyup],a[rel|rev|charset|hreflang|tabindex|accesskey|type|"
+							+ "name|href|target|title|class|onfocus|onblur],strong/b,i/em,strike,u,"
 							+ "#p,-ol[type|compact],-ul[type|compact],-li,br,img[longdesc|usemap|"
 							+ "src|border|alt=|title|hspace|vspace|width|height|align],-sub,-sup,"
 							+ "-blockquote,-table[border=0|cellspacing|cellpadding|width|frame|rules|"
@@ -197,10 +200,11 @@
 							+ "object[classid|width|height|codebase|*],param[name|value|_value],embed[type|width"
 							+ "|height|src|*],script[src|type],map[name],area[shape|coords|href|alt|target],bdo,"
 							+ "button,col[align|char|charoff|span|valign|width],colgroup[align|char|charoff|span|"
-							+ "valign|width],dfn,fieldset,"
-							+ "kbd,label[for],legend,noscript,"
-							+ "q[cite],samp,small,"
-							+ "tt,var,big"
+							+ "valign|width],dfn,fieldset,form[action|accept|accept-charset|enctype|method],"
+							+ "input[accept|alt|checked|disabled|maxlength|name|readonly|size|src|type|value],"
+							+ "kbd,label[for],legend,noscript,optgroup[label|disabled],option[disabled|label|selected|value],"
+							+ "q[cite],samp,select[disabled|multiple|name|size],small,"
+							+ "textarea[cols|rows|disabled|name|readonly],tt,var,big"
 				};
 
 				$scope.tableOfContentsEditorOptions = {
@@ -210,24 +214,7 @@
 	    						italic: {inline: 'i'}
 	  						},
 						browser_spellcheck : true,
-						toolbar : 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | subscript superscript | link | code',
-						valid_elements : "strong/b,i/em,strike,u,"
-								+ "#p,-ol[type|compact],-ul[type|compact],-li,br,img[longdesc|usemap|"
-								+ "src|border|alt=|title|hspace|vspace|width|height|align],-sub,-sup,"
-								+ "-blockquote,-table[border=0|cellspacing|cellpadding|width|frame|rules|"
-								+ "height|align|summary|bgcolor|background|bordercolor],-tr[rowspan|width|"
-								+ "height|align|valign|bgcolor|background|bordercolor],tbody,thead,tfoot,"
-								+ "#td[colspan|rowspan|width|height|align|valign|bgcolor|background|bordercolor"
-								+ "|scope],#th[colspan|rowspan|width|height|align|valign|scope],caption,-div,"
-								+ "-span,-code,-pre,address,-h1,-h2,-h3,-h4,-h5,-h6,hr[size|noshade],-font[face"
-								+ "|size|color],dd,dl,dt,cite,abbr,acronym,del[datetime|cite],ins[datetime|cite],"
-								+ "object[classid|width|height|codebase|*],param[name|value|_value],embed[type|width"
-								+ "|height|src|*],script[src|type],map[name],area[shape|coords|href|alt|target],bdo,"
-								+ "button,col[align|char|charoff|span|valign|width],colgroup[align|char|charoff|span|"
-								+ "valign|width],dfn,fieldset,"
-								+ "kbd,label[for],legend,noscript,"
-								+ "q[cite],samp,small,"
-								+ "tt,var,big"
+						toolbar : 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | subscript superscript | link | code'
 					};
 
 			}]);

--- a/pw-mypubs-ui/src/main/webapp/mypubs/publication/spn/spn.js
+++ b/pw-mypubs-ui/src/main/webapp/mypubs/publication/spn/spn.js
@@ -86,23 +86,7 @@ angular.module('pw.spn', ['pw.lookups'])
   						},
 					browser_spellcheck : true,
 					toolbar : 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | subscript superscript | link | code',
-					valid_elements : "strong/b,i/em,strike,u,"
-							+ "#p,-ol[type|compact],-ul[type|compact],-li,br,img[longdesc|usemap|"
-							+ "src|border|alt=|title|hspace|vspace|width|height|align],-sub,-sup,"
-							+ "-blockquote,-table[border=0|cellspacing|cellpadding|width|frame|rules|"
-							+ "height|align|summary|bgcolor|background|bordercolor],-tr[rowspan|width|"
-							+ "height|align|valign|bgcolor|background|bordercolor],tbody,thead,tfoot,"
-							+ "#td[colspan|rowspan|width|height|align|valign|bgcolor|background|bordercolor"
-							+ "|scope],#th[colspan|rowspan|width|height|align|valign|scope],caption,-div,"
-							+ "-span,-code,-pre,address,-h1,-h2,-h3,-h4,-h5,-h6,hr[size|noshade],-font[face"
-							+ "|size|color],dd,dl,dt,cite,abbr,acronym,del[datetime|cite],ins[datetime|cite],"
-							+ "object[classid|width|height|codebase|*],param[name|value|_value],embed[type|width"
-							+ "|height|src|*],script[src|type],map[name],area[shape|coords|href|alt|target],bdo,"
-							+ "button,col[align|char|charoff|span|valign|width],colgroup[align|char|charoff|span|"
-							+ "valign|width],dfn,fieldset,"
-							+ "kbd,label[for],legend,noscript,"
-							+ "q[cite],samp,small,"
-							+ "tt,var,big"
+					
 				};
 		}
 	]);

--- a/pw-mypubs-ui/src/main/webapp/mypubs/publication/spn/spn.js
+++ b/pw-mypubs-ui/src/main/webapp/mypubs/publication/spn/spn.js
@@ -85,7 +85,7 @@ angular.module('pw.spn', ['pw.lookups'])
     						italic: {inline: 'i'}
   						},
 					browser_spellcheck : true,
-					toolbar : 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | subscript superscript | link | code',
+					toolbar : 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | subscript superscript | link | code'
 					
 				};
 		}


### PR DESCRIPTION
The stripped down tag set was messing with tinyMCE functionality.   Removed the custom tag set altogether for address and table of contents, added the full tagset for the abstract area so that the i/em switch will continue to work